### PR TITLE
Add basic support for 256 color mode

### DIFF
--- a/examples/hello-256-world.rs
+++ b/examples/hello-256-world.rs
@@ -1,0 +1,30 @@
+extern crate rustbox;
+
+use std::default::Default;
+
+use rustbox::{Color, RustBox, OutputMode};
+use rustbox::Key;
+
+fn main() {
+    let mut rustbox = match RustBox::init(Default::default()) {
+        Result::Ok(v) => v,
+        Result::Err(e) => panic!("{}", e),
+    };
+    rustbox.set_output_mode(OutputMode::EightBit);
+
+    rustbox.print(1, 1, rustbox::RB_BOLD, Color::Byte(0xa2), Color::Black, "Hello, world!");
+    rustbox.print(1, 3, rustbox::RB_NORMAL, Color::Black, Color::Byte(0x9a), "Press 'q' to quit.");
+    loop {
+        rustbox.present();
+        match rustbox.poll_event(false) {
+            Ok(rustbox::Event::KeyEvent(key)) => {
+                match key {
+                    Key::Char('q') => { break; }
+                    _ => { }
+                }
+            },
+            Err(e) => panic!("{}", e),
+            _ => { }
+        }
+    }
+}


### PR DESCRIPTION
Usage:

Simply set the output mode: rustbox.set_output_mode(OutputMode::EightBit);

And use Color::Byte(0x13) to select a specific color, or use the same
old Color::Red num values for the standard colors.

--  BY  @ryanwilliamms